### PR TITLE
Fix Desktop Picture assignment

### DIFF
--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -9,6 +9,12 @@
       changed_when: no
       register: BackGroundImage_New
 
+    - name: "Desktop & Screen Saver - Set the destination path for {{ DesktopScreenSaver_BackGroundImage |  basename }}"
+      set_fact:
+        new_background_picture_dest_path: "{{ item }}"
+      loop:
+        - "$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
+
     - name: "Desktop & Screen Saver - Get the current background image"
       command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data limit 1";
       changed_when: no
@@ -19,7 +25,7 @@
       - name: Copy '{{ DesktopScreenSaver_BackGroundImage | basename }}' image to '~/Pictures'
         copy:
           src: "{{ DesktopScreenSaver_BackGroundImage }}"
-          dest: "$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
+          dest: "{{ new_background_picture_dest_path }}"
           owner: "{{ target_user_id }}"
           mode: '0644'
 
@@ -35,7 +41,7 @@
               - "DELETE FROM prefs;"
               # - "DELETE FROM spaces;"
               - "INSERT INTO pictures (space_id, display_id) VALUES (null, null);"
-              - "INSERT INTO data (value) VALUES ('$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}');" # Picture for standard backgroup
+              - "INSERT INTO data (value) VALUES ('{{ new_background_picture_dest_path }}');" # Picture for standard backgroup
               - "INSERT INTO data (value) VALUES (1);" # Scaling method (Fill Screen (1), Center (3), Stretch to Fill Screen (4), Fit to Screen (5))
               - "INSERT INTO data (value) VALUES (0.07);" # Fill color
               - "INSERT INTO preferences (key, data_id, picture_id) VALUES (1, 1, 1);" # Set the `Image path`, to `entry 1` of data table for 1st picture (which in our case means all spaces/displays by default).
@@ -56,7 +62,7 @@
       # end block
       when:
         - BackGroundImage_New.stat.exists
-        - BackGroundImage_Current.stdout != "$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
+        - BackGroundImage_Current.stdout != new_background_picture_dest_path
     # end block
     when: DesktopScreenSaver_BackGroundImage is defined and DesktopScreenSaver_BackGroundImage != ''
 

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -12,9 +12,7 @@
     set_fact:
       new_background_picture_dest_path: "{{ item | expanduser }}"
     loop:
-      - "~/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
-    become: "{{ target_user_id != ansible_user_id }}"
-    become_user: "{{ target_user_id }}"
+      - "/Users/{{ target_user_id }}/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
 
   - name: new_background_picture_dest_path
     debug:

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -1,73 +1,64 @@
 ---
 - block:
-
-  - name: "Desktop & Screen Saver - Check if background image exists"
-    stat:
-      path: "{{ DesktopScreenSaver_BackGroundImage }}"
-    changed_when: no
-    register: BackGroundImage_New
-    when: DesktopScreenSaver_BackGroundImage is defined
-
-  - name:
+  - name: When DesktopScreenSaver_BackGroundImage is defined
     block:
 
-    - name: Copy '{{ DesktopScreenSaver_BackGroundImage | basename }}' image to '~/Pictures'
-      copy:
-        src: "{{ DesktopScreenSaver_BackGroundImage }}"
-        dest: "$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
-        owner: "{{ target_user_id }}"
-        mode: '0644'
+    - name: "Desktop & Screen Saver - Check if background image exists"
+      stat:
+        path: "{{ DesktopScreenSaver_BackGroundImage }}"
+      changed_when: no
+      register: BackGroundImage_New
 
-    - name: Backgroup Image for macOS 10.9 to 10.14
+    - name: "Desktop & Screen Saver - Get the current background image"
+      command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data limit 1";
+      changed_when: no
+      register: BackGroundImage_Current
+
+    - name: When current image is different than DesktopScreenSaver_BackGroundImage
       block:
-      - name: "Desktop & Screen Saver - Get the current background image"
-        command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data";
-        changed_when: no
-        register: BackGroundImage_Current
+      - name: Copy '{{ DesktopScreenSaver_BackGroundImage | basename }}' image to '~/Pictures'
+        copy:
+          src: "{{ DesktopScreenSaver_BackGroundImage }}"
+          dest: "$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
+          owner: "{{ target_user_id }}"
+          mode: '0644'
 
-      - name: "Desktop & Screen Saver - Change desktop background"
-        command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '{{ item }}'";
-        loop:
-          - "$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
-        when:
-          - BackGroundImage_New.stat.exists
-          - BackGroundImage_Current.stdout != DesktopScreenSaver_BackGroundImage
-        notify: restart Dock
+      - name: When macOS versio is 10.9 or superior
+        block:
+          - name: "Desktop & Screen Saver - Change desktop background"
+            command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "{{ item }}"
+            loop:
+              - "DELETE FROM data;"
+              - "DELETE FROM displays;"
+              - "DELETE FROM pictures;"
+              - "DELETE FROM preferences;"
+              - "DELETE FROM prefs;"
+              # - "DELETE FROM spaces;"
+              - "INSERT INTO pictures (space_id, display_id) VALUES (null, null);"
+              - "INSERT INTO data (value) VALUES ('$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}');" # Picture for standard backgroup
+              - "INSERT INTO data (value) VALUES (1);" # Scaling method (Fill Screen (1), Center (3), Stretch to Fill Screen (4), Fit to Screen (5))
+              - "INSERT INTO data (value) VALUES (0.07);" # Fill color
+              - "INSERT INTO preferences (key, data_id, picture_id) VALUES (1, 1, 1);" # Set the `Image path`, to `entry 1` of data table for 1st picture (which in our case means all spaces/displays by default).
+              - "INSERT INTO preferences (key, data_id, picture_id) VALUES (2, 2, 1);" # set Scaling method to 'entry 2' of data table
+              - "INSERT INTO preferences (key, data_id, picture_id) VALUES (3, 3, 1);" # set fill colour to 'entry 3' of data table
+              - "INSERT INTO preferences (key, data_id, picture_id) VALUES (4, 3, 1);" # set fill colour to 'entry 3' of data table
+              - "INSERT INTO preferences (key, data_id, picture_id) VALUES (5, 3, 1);" # set fill colour to 'entry 3' of data table
+              # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (9, 3, 1);" # Enable automatic changing
+              # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (10, 3, 1);" # Directory path to images
+              # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (11, 3, 1);" # Image changing interval
+              # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (12, 3, 1);" # Random order
+              # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (16, 3, 1);" # Current image (used when automatic
+              # matrix explained at
+              # https://stackoverflow.com/questions/33533304/change-scaling-for-all-desktop-backgrounds-on-mac-via-a-script/42194904 changing is enabled)
+            notify: restart Dock
+        # end block
+        when: ansible_facts['distribution_version'] is version('10.9', '>=')
       # end block
-      when: ansible_facts['distribution_version'] is version('10.9', '>=') and ansible_facts['distribution_version'] is version('10.15', '<')
-
-    - name: Backgroup Image for macOS 10.15 or superior
-      block:
-        - name: "Desktop & Screen Saver - Change desktop background"
-          command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "{{ item }}"
-          loop:
-            - "DELETE FROM data;"
-            - "DELETE FROM displays;"
-            - "DELETE FROM pictures;"
-            - "DELETE FROM preferences;"
-            - "DELETE FROM prefs;"
-            # - "DELETE FROM spaces;"
-            - "INSERT INTO pictures (space_id, display_id) VALUES (null, null);"
-            - "INSERT INTO data (value) VALUES ('$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}');" # Picture for standard backgroup
-            - "INSERT INTO data (value) VALUES (1);" # Scaling method (Fill Screen (1), Center (3), Stretch to Fill Screen (4), Fit to Screen (5))
-            - "INSERT INTO data (value) VALUES (0.07);" # Fill color
-            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (1, 1, 1);" # Set the `Image path`, to `entry 1` of data table for 1st picture (which in our case means all spaces/displays by default).
-            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (2, 2, 1);" # set Scaling method to 'entry 2' of data table
-            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (3, 3, 1);" # set fill colour to 'entry 3' of data table
-            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (4, 3, 1);" # set fill colour to 'entry 3' of data table
-            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (5, 3, 1);" # set fill colour to 'entry 3' of data table
-            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (9, 3, 1);" # Enable automatic changing
-            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (10, 3, 1);" # Directory path to images
-            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (11, 3, 1);" # Image changing interval
-            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (12, 3, 1);" # Random order
-            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (16, 3, 1);" # Current image (used when automatic changing is enabled)
-          notify: restart Dock
-      # end block
-      when: ansible_facts['distribution_version'] is version('10.15', '>=')
+      when:
+        - BackGroundImage_New.stat.exists
+        - BackGroundImage_Current.stdout != "$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
     # end block
-    when:
-      - DesktopScreenSaver_BackGroundImage is defined
-      - BackGroundImage_New.stat.exists
+    when: DesktopScreenSaver_BackGroundImage is defined and DesktopScreenSaver_BackGroundImage != ''
 
   - name: "Desktop & Screen Saver - Require password after sleep or screen saver begins"
     osx_defaults: { domain: 'com.apple.screensaver', key: 'askForPassword', type: int, value: "{{ item.value }}" }

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -15,20 +15,10 @@
       loop:
         - "~/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
 
-    - name: new_background_picture_dest_path
-      debug:
-        var: new_background_picture_dest_path
-      when: verbose | bool
-
     - name: "Desktop & Screen Saver - Get the current background image"
       command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data limit 1";
       changed_when: no
       register: BackGroundImage_Current
-
-    - name: BackGroundImage_Current
-      debug:
-        var: BackGroundImage_Current
-      when: verbose | bool
 
     - name: When current image is different than DesktopScreenSaver_BackGroundImage
       block:

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -25,24 +25,34 @@
       command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data limit 1";
       changed_when: no
       register: BackGroundImage_Current
+      ignore_errors: no
       become: "{{ target_user_id != ansible_user_id }}"
       become_user: "{{ target_user_id }}"
 
+
     rescue:
-    - name: "Copy {{ ansible_user_id }}'s desktoppicture.db into {{ target_user_id }} home dir."
-      copy:
-        remote_src: yes
-        src: "/Users/{{ ansible_user_id }}/Library/Application\ Support/Dock/desktoppicture.db"
-        dest: "/Users/{{ target_user_id }}/Library/Application\ Support/Dock/desktoppicture.db"
-        force: yes
-        owner: "{{ target_user_id }}"
-        mode: '0644'
+    - block:
+      - name: "Make sure that '/Users/{{ target_user_id }}/Library/Application\ Support/Dock/' exists."
+        file:
+          path: "/Users/{{ target_user_id }}/Library/Application\ Support/Dock/"
+          state: directory
+          owner: "{{ target_user_id }}"
+          mode: '0755'
+          
+      - name: "Copy {{ ansible_user_id }}'s desktoppicture.db into {{ target_user_id }} home dir."
+        copy:
+          remote_src: yes
+          src: "/Users/{{ ansible_user_id }}/Library/Application\ Support/Dock/desktoppicture.db"
+          dest: "/Users/{{ target_user_id }}/Library/Application\ Support/Dock/desktoppicture.db"
+          force: yes
+          owner: "{{ target_user_id }}"
+          mode: '0644'
       become: yes
-      when: target_user_id != ansible_user_id
+      when: (target_user_id != ansible_user_id)
 
   - name: When current image is different than DesktopScreenSaver_BackGroundImage
     block:
-    - name: Copy '{{ DesktopScreenSaver_BackGroundImage | basename }}' image to '~/Pictures'
+    - name: "Copy '{{ DesktopScreenSaver_BackGroundImage | basename }}' image to '~/Pictures'"
       copy:
         src: "{{ DesktopScreenSaver_BackGroundImage }}"
         dest: "{{ new_background_picture_dest_path }}"

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -1,75 +1,86 @@
 ---
-- block:
-  - name: When DesktopScreenSaver_BackGroundImage is defined
+- name: When DesktopScreenSaver_BackGroundImage is defined
+  block:
+
+  - name: "Desktop & Screen Saver - Check if background image exists"
+    stat:
+      path: "{{ DesktopScreenSaver_BackGroundImage }}"
+    changed_when: no
+    register: BackGroundImage_New
+
+  - name: "Desktop & Screen Saver - Set the destination path for {{ DesktopScreenSaver_BackGroundImage |  basename }}"
+    set_fact:
+      new_background_picture_dest_path: "{{ item | expanduser }}"
+    loop:
+      - "~/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
+    become: "{{ target_user_id != ansible_user_id }}"
+    become_user: "{{ target_user_id }}"
+
+  - name: new_background_picture_dest_path
+    debug:
+      var: new_background_picture_dest_path
+    when: verbose | bool
+
+  - name: "Desktop & Screen Saver - Get the current background image"
+    command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data limit 1";
+    changed_when: no
+    register: BackGroundImage_Current
+    become: "{{ target_user_id != ansible_user_id }}"
+    become_user: "{{ target_user_id }}"
+
+  - name: When current image is different than DesktopScreenSaver_BackGroundImage
     block:
+    - name: Copy '{{ DesktopScreenSaver_BackGroundImage | basename }}' image to '~/Pictures'
+      copy:
+        src: "{{ DesktopScreenSaver_BackGroundImage }}"
+        dest: "{{ new_background_picture_dest_path }}"
+        owner: "{{ target_user_id }}"
+        mode: '0644'
+      become: yes
 
-    - name: "Desktop & Screen Saver - Check if background image exists"
-      stat:
-        path: "{{ DesktopScreenSaver_BackGroundImage }}"
-      changed_when: no
-      register: BackGroundImage_New
-
-    - name: "Desktop & Screen Saver - Set the destination path for {{ DesktopScreenSaver_BackGroundImage |  basename }}"
-      set_fact:
-        new_background_picture_dest_path: "{{ item }}"
-      loop:
-        - "~/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
-
-    - name: "Desktop & Screen Saver - Get the current background image"
-      command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data limit 1";
-      changed_when: no
-      register: BackGroundImage_Current
-
-    - name: When current image is different than DesktopScreenSaver_BackGroundImage
+    - name: When macOS versio is 10.9 or superior
       block:
-      - name: Copy '{{ DesktopScreenSaver_BackGroundImage | basename }}' image to '~/Pictures'
-        copy:
-          src: "{{ DesktopScreenSaver_BackGroundImage }}"
-          dest: "{{ new_background_picture_dest_path }}"
-          owner: "{{ target_user_id }}"
-          mode: '0644'
-
-      - name: When macOS versio is 10.9 or superior
-        block:
-          - name: "Desktop & Screen Saver - Change desktop background"
-            command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "{{ item }}"
-            loop:
-              - "DELETE FROM data;"
-              - "DELETE FROM displays;"
-              - "DELETE FROM pictures;"
-              - "DELETE FROM preferences;"
-              - "DELETE FROM prefs;"
-              # - "DELETE FROM spaces;"
-              - "INSERT INTO pictures (space_id, display_id) VALUES (null, null);"
-              - "INSERT INTO data (value) VALUES ('{{ new_background_picture_dest_path }}');" # Picture for standard backgroup
-              - "INSERT INTO data (value) VALUES (1);" # Scaling method (Fill Screen (1), Center (3), Stretch to Fill Screen (4), Fit to Screen (5))
-              - "INSERT INTO data (value) VALUES (0.07);" # Fill color
-              - "INSERT INTO preferences (key, data_id, picture_id) VALUES (1, 1, 1);" # Set the `Image path`, to `entry 1` of data table for 1st picture (which in our case means all spaces/displays by default).
-              - "INSERT INTO preferences (key, data_id, picture_id) VALUES (2, 2, 1);" # set Scaling method to 'entry 2' of data table
-              - "INSERT INTO preferences (key, data_id, picture_id) VALUES (3, 3, 1);" # set fill colour to 'entry 3' of data table
-              - "INSERT INTO preferences (key, data_id, picture_id) VALUES (4, 3, 1);" # set fill colour to 'entry 3' of data table
-              - "INSERT INTO preferences (key, data_id, picture_id) VALUES (5, 3, 1);" # set fill colour to 'entry 3' of data table
-              # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (9, 3, 1);" # Enable automatic changing
-              # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (10, 3, 1);" # Directory path to images
-              # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (11, 3, 1);" # Image changing interval
-              # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (12, 3, 1);" # Random order
-              # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (16, 3, 1);" # Current image (used when automatic
-              # matrix explained at
-              # https://stackoverflow.com/questions/33533304/change-scaling-for-all-desktop-backgrounds-on-mac-via-a-script/42194904 changing is enabled)
-            notify: restart Dock
-        # end block
-        when: ansible_facts['distribution_version'] is version('10.9', '>=')
+        - name: "Desktop & Screen Saver - Change desktop background"
+          command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "{{ item }}"
+          loop:
+            - "DELETE FROM data;"
+            - "DELETE FROM displays;"
+            - "DELETE FROM pictures;"
+            - "DELETE FROM preferences;"
+            - "DELETE FROM prefs;"
+            # - "DELETE FROM spaces;"
+            - "INSERT INTO pictures (space_id, display_id) VALUES (null, null);"
+            - "INSERT INTO data (value) VALUES ('{{ new_background_picture_dest_path }}');" # Picture for standard backgroup
+            - "INSERT INTO data (value) VALUES (1);" # Scaling method (Fill Screen (1), Center (3), Stretch to Fill Screen (4), Fit to Screen (5))
+            - "INSERT INTO data (value) VALUES (0.07);" # Fill color
+            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (1, 1, 1);" # Set the `Image path`, to `entry 1` of data table for 1st picture (which in our case means all spaces/displays by default).
+            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (2, 2, 1);" # set Scaling method to 'entry 2' of data table
+            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (3, 3, 1);" # set fill colour to 'entry 3' of data table
+            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (4, 3, 1);" # set fill colour to 'entry 3' of data table
+            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (5, 3, 1);" # set fill colour to 'entry 3' of data table
+            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (9, 3, 1);" # Enable automatic changing
+            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (10, 3, 1);" # Directory path to images
+            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (11, 3, 1);" # Image changing interval
+            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (12, 3, 1);" # Random order
+            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (16, 3, 1);" # Current image (used when automatic
+            # matrix explained at
+            # https://stackoverflow.com/questions/33533304/change-scaling-for-all-desktop-backgrounds-on-mac-via-a-script/42194904 changing is enabled)
+          become: "{{ target_user_id != ansible_user_id }}"
+          become_user: "{{ target_user_id }}"
+          notify: restart Dock
       # end block
-      when:
-        - BackGroundImage_New.stat.exists
-        - BackGroundImage_Current.stdout != new_background_picture_dest_path | expanduser
+      when: ansible_facts['distribution_version'] is version('10.9', '>=')
     # end block
-    when: DesktopScreenSaver_BackGroundImage is defined and DesktopScreenSaver_BackGroundImage != ''
+    when:
+      - BackGroundImage_New.stat.exists
+      - BackGroundImage_Current.stdout != new_background_picture_dest_path
+  # end block
+  when: DesktopScreenSaver_BackGroundImage is defined and DesktopScreenSaver_BackGroundImage != ''
 
-  - name: "Desktop & Screen Saver - Require password after sleep or screen saver begins"
-    osx_defaults: { domain: 'com.apple.screensaver', key: 'askForPassword', type: int, value: "{{ item.value }}" }
-    loop: "{{ EnabledDisabled_Options_Integer }}"
-    when: item.name == DesktopScreenSaver_askForPassword
+- name: "Desktop & Screen Saver - Require password after sleep or screen saver begins"
+  osx_defaults: { domain: 'com.apple.screensaver', key: 'askForPassword', type: int, value: "{{ item.value }}" }
+  loop: "{{ EnabledDisabled_Options_Integer }}"
+  when: item.name == DesktopScreenSaver_askForPassword
   # Privilege escalation to `target_user_id` is only required for inner steps when
   # the `target_user_id` doesn't match the `ansible_user_id`
   become: "{{ target_user_id != ansible_user_id }}"

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -1,22 +1,62 @@
 ---
 - block:
-  - name: "Desktop & Screen Saver - Get the current background image"
-    command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data";
-    changed_when: no
-    register: BackGroundImage_Current
+  - block:
+    - name: Backgroup Image for macOS 10.9 to 10.14
+      block:
+      - name: "Desktop & Screen Saver - Get the current background image"
+        command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data";
+        changed_when: no
+        register: BackGroundImage_Current
 
-  - name: "Desktop & Screen Saver - Check if background image exists"
-    stat:
-      path: "{{ DesktopScreenSaver_BackGroundImage }}"
-    changed_when: no
-    register: BackGroundImage_New
+      - name: "Desktop & Screen Saver - Check if background image exists"
+        stat:
+          path: "{{ DesktopScreenSaver_BackGroundImage }}"
+        changed_when: no
+        register: BackGroundImage_New
 
-  - name: "Desktop & Screen Saver - Change desktop background"
-    command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '{{ item }}'";
-    loop:
-      - "{{ DesktopScreenSaver_BackGroundImage }}"
-    when: DesktopScreenSaver_BackGroundImage is defined and BackGroundImage_New.stat.exists and BackGroundImage_Current.stdout != DesktopScreenSaver_BackGroundImage
-    notify: restart Dock
+      - name: "Desktop & Screen Saver - Change desktop background"
+        command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '{{ item }}'";
+        loop:
+          - "{{ DesktopScreenSaver_BackGroundImage }}"
+        when:
+          - BackGroundImage_New.stat.exists
+          - BackGroundImage_Current.stdout != DesktopScreenSaver_BackGroundImage
+        notify: restart Dock
+      # end block
+      when: ansible_facts['distribution_version'] is version('10.9', '>=') and ansible_facts['distribution_version'] is version('10.15', '<')
+
+    - name: Backgroup Image for macOS 10.15 or superior
+      block:
+        - name: "Desktop & Screen Saver - Change desktop background"
+          command:
+            argv:
+              - sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db {{ item }}
+          loop:
+            - "DELETE FROM data;"
+            - "DELETE FROM displays;"
+            - "DELETE FROM pictures;"
+            - "DELETE FROM preferences;"
+            - "DELETE FROM prefs;"
+            # - "DELETE FROM spaces;"
+            - "INSERT INTO pictures (space_id, display_id) VALUES (null, null);"
+            - "INSERT INTO data (value) VALUES ('{{ DesktopScreenSaver_BackGroundImage }}');" # Picture for standard backgroup
+            - "INSERT INTO data (value) VALUES (1);" # Scaling method (Fill Screen (1), Center (3), Stretch to Fill Screen (4), Fit to Screen (5))
+            - "INSERT INTO data (value) VALUES (0.07);" # Fill color
+            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (1, 1, 1);" # Set the `Image path`, to `entry 1` of data table for 1st picture (which in our case means all spaces/displays by default).
+            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (2, 2, 1);" # set Scaling method to 'entry 2' of data table
+            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (3, 3, 1);" # set fill colour to 'entry 3' of data table
+            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (4, 3, 1);" # set fill colour to 'entry 3' of data table
+            - "INSERT INTO preferences (key, data_id, picture_id) VALUES (5, 3, 1);" # set fill colour to 'entry 3' of data table
+            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (9, 3, 1);" # Enable automatic changing
+            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (10, 3, 1);" # Directory path to images
+            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (11, 3, 1);" # Image changing interval
+            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (12, 3, 1);" # Random order
+            # - "INSERT INTO preferences (key, data_id, picture_id) VALUES (16, 3, 1);" # Current image (used when automatic changing is enabled)
+          notify: restart Dock
+      # end block
+      when: ansible_facts['distribution_version'] is version('10.15', '>=')
+    # end block
+    when: DesktopScreenSaver_BackGroundImage is defined
 
   - name: "Desktop & Screen Saver - Require password after sleep or screen saver begins"
     osx_defaults: { domain: 'com.apple.screensaver', key: 'askForPassword', type: int, value: "{{ item.value }}" }

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -13,7 +13,7 @@
       set_fact:
         new_background_picture_dest_path: "{{ item }}"
       loop:
-        - "$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
+        - "~/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
 
     - name: new_background_picture_dest_path
       debug:

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -1,6 +1,23 @@
 ---
 - block:
-  - block:
+
+  - name: "Desktop & Screen Saver - Check if background image exists"
+    stat:
+      path: "{{ DesktopScreenSaver_BackGroundImage }}"
+    changed_when: no
+    register: BackGroundImage_New
+    when: DesktopScreenSaver_BackGroundImage is defined
+
+  - name:
+    block:
+
+    - name: Copy '{{ DesktopScreenSaver_BackGroundImage | basename }}' image to '~/Pictures'
+      copy:
+        src: "{{ DesktopScreenSaver_BackGroundImage }}"
+        dest: "$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
+        owner: "{{ target_user_id }}"
+        mode: '0644'
+
     - name: Backgroup Image for macOS 10.9 to 10.14
       block:
       - name: "Desktop & Screen Saver - Get the current background image"
@@ -8,16 +25,10 @@
         changed_when: no
         register: BackGroundImage_Current
 
-      - name: "Desktop & Screen Saver - Check if background image exists"
-        stat:
-          path: "{{ DesktopScreenSaver_BackGroundImage }}"
-        changed_when: no
-        register: BackGroundImage_New
-
       - name: "Desktop & Screen Saver - Change desktop background"
         command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '{{ item }}'";
         loop:
-          - "{{ DesktopScreenSaver_BackGroundImage }}"
+          - "$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
         when:
           - BackGroundImage_New.stat.exists
           - BackGroundImage_Current.stdout != DesktopScreenSaver_BackGroundImage
@@ -37,7 +48,7 @@
             - "DELETE FROM prefs;"
             # - "DELETE FROM spaces;"
             - "INSERT INTO pictures (space_id, display_id) VALUES (null, null);"
-            - "INSERT INTO data (value) VALUES ('{{ DesktopScreenSaver_BackGroundImage }}');" # Picture for standard backgroup
+            - "INSERT INTO data (value) VALUES ('$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}');" # Picture for standard backgroup
             - "INSERT INTO data (value) VALUES (1);" # Scaling method (Fill Screen (1), Center (3), Stretch to Fill Screen (4), Fit to Screen (5))
             - "INSERT INTO data (value) VALUES (0.07);" # Fill color
             - "INSERT INTO preferences (key, data_id, picture_id) VALUES (1, 1, 1);" # Set the `Image path`, to `entry 1` of data table for 1st picture (which in our case means all spaces/displays by default).
@@ -54,7 +65,9 @@
       # end block
       when: ansible_facts['distribution_version'] is version('10.15', '>=')
     # end block
-    when: DesktopScreenSaver_BackGroundImage is defined
+    when:
+      - DesktopScreenSaver_BackGroundImage is defined
+      - BackGroundImage_New.stat.exists
 
   - name: "Desktop & Screen Saver - Require password after sleep or screen saver begins"
     osx_defaults: { domain: 'com.apple.screensaver', key: 'askForPassword', type: int, value: "{{ item.value }}" }

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -18,7 +18,7 @@
     - name: new_background_picture_dest_path
       debug:
         var: new_background_picture_dest_path
-      when: bool|true
+      when: varbose | bool
 
     - name: "Desktop & Screen Saver - Get the current background image"
       command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data limit 1";
@@ -28,7 +28,7 @@
     - name: BackGroundImage_Current
       debug:
         var: BackGroundImage_Current
-      when: bool|true
+      when: varbose | bool
 
     - name: When current image is different than DesktopScreenSaver_BackGroundImage
       block:

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -15,10 +15,20 @@
       loop:
         - "$HOME/Pictures/{{ DesktopScreenSaver_BackGroundImage | basename }}"
 
+    - name: new_background_picture_dest_path
+      debug:
+        var: new_background_picture_dest_path
+      when: bool|true
+
     - name: "Desktop & Screen Saver - Get the current background image"
       command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data limit 1";
       changed_when: no
       register: BackGroundImage_Current
+
+    - name: BackGroundImage_Current
+      debug:
+        var: BackGroundImage_Current
+      when: bool|true
 
     - name: When current image is different than DesktopScreenSaver_BackGroundImage
       block:
@@ -62,7 +72,7 @@
       # end block
       when:
         - BackGroundImage_New.stat.exists
-        - BackGroundImage_Current.stdout != new_background_picture_dest_path
+        - BackGroundImage_Current.stdout != new_background_picture_dest_path | expanduser
     # end block
     when: DesktopScreenSaver_BackGroundImage is defined and DesktopScreenSaver_BackGroundImage != ''
 

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -29,16 +29,16 @@
       become: "{{ target_user_id != ansible_user_id }}"
       become_user: "{{ target_user_id }}"
 
-
     rescue:
-    - block:
+    - name: rescue tasks that is executed only in case the previous task(s) fail
+      block:
       - name: "Make sure that '/Users/{{ target_user_id }}/Library/Application\ Support/Dock/' exists."
         file:
           path: "/Users/{{ target_user_id }}/Library/Application\ Support/Dock/"
           state: directory
           owner: "{{ target_user_id }}"
           mode: '0755'
-          
+
       - name: "Copy {{ ansible_user_id }}'s desktoppicture.db into {{ target_user_id }} home dir."
         copy:
           remote_src: yes

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -18,7 +18,7 @@
     - name: new_background_picture_dest_path
       debug:
         var: new_background_picture_dest_path
-      when: varbose | bool
+      when: verbose | bool
 
     - name: "Desktop & Screen Saver - Get the current background image"
       command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data limit 1";
@@ -28,7 +28,7 @@
     - name: BackGroundImage_Current
       debug:
         var: BackGroundImage_Current
-      when: varbose | bool
+      when: verbose | bool
 
     - name: When current image is different than DesktopScreenSaver_BackGroundImage
       block:

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -19,12 +19,26 @@
       var: new_background_picture_dest_path
     when: verbose | bool
 
-  - name: "Desktop & Screen Saver - Get the current background image"
-    command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data limit 1";
-    changed_when: no
-    register: BackGroundImage_Current
-    become: "{{ target_user_id != ansible_user_id }}"
-    become_user: "{{ target_user_id }}"
+  - name: try to get information about the current background image
+    block:
+    - name: "Desktop & Screen Saver - Get the current background image"
+      command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "select value from data limit 1";
+      changed_when: no
+      register: BackGroundImage_Current
+      become: "{{ target_user_id != ansible_user_id }}"
+      become_user: "{{ target_user_id }}"
+
+    rescue:
+    - name: "Copy {{ ansible_user_id }}'s desktoppicture.db into {{ target_user_id }} home dir."
+      copy:
+        remote_src: yes
+        src: "/Users/{{ ansible_user_id }}/Library/Application\ Support/Dock/desktoppicture.db"
+        dest: "/Users/{{ target_user_id }}/Library/Application\ Support/Dock/desktoppicture.db"
+        force: yes
+        owner: "{{ target_user_id }}"
+        mode: '0644'
+      become: yes
+      when: target_user_id != ansible_user_id
 
   - name: When current image is different than DesktopScreenSaver_BackGroundImage
     block:

--- a/tasks/desktop-screen-saver.yml
+++ b/tasks/desktop-screen-saver.yml
@@ -28,9 +28,7 @@
     - name: Backgroup Image for macOS 10.15 or superior
       block:
         - name: "Desktop & Screen Saver - Change desktop background"
-          command:
-            argv:
-              - sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db {{ item }}
+          command: sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "{{ item }}"
           loop:
             - "DELETE FROM data;"
             - "DELETE FROM displays;"

--- a/tasks/hot-corners.yml
+++ b/tasks/hot-corners.yml
@@ -1,7 +1,7 @@
 ---
 - block:
   - name: "Hot Corners - Modifiers"
-    osx_defaults: { domain: 'com.apple.dock', key: "{{ item.0.key }}", type: int, value: "{{ item.1.value}}" }
+    osx_defaults: { domain: 'com.apple.dock', key: "{{ item.0.key }}", type: int, value: "{{ item.1.value }}" }
     with_subelements:
       - "{{ HotCorners_Modifiers }}"
       - value
@@ -13,7 +13,7 @@
     notify: restart Dock
 
   - name: "Hot Corners - Actions"
-    osx_defaults: { domain: 'com.apple.dock', key: "{{ item.0.key }}", type: int, value: "{{ item.1.value}}" }
+    osx_defaults: { domain: 'com.apple.dock', key: "{{ item.0.key }}", type: int, value: "{{ item.1.value }}" }
     with_subelements:
       - "{{ HotCorners_Actions }}"
       - value

--- a/tasks/setup-assistant.yml
+++ b/tasks/setup-assistant.yml
@@ -21,13 +21,13 @@
       - { key: "SkipFirstLoginOptimization",                  type: "bool",   value: "{{ SetupAssistant_SkipFirstLoginOptimization }}" }
       - { key: "LastPrivacyBundleVersion",                    type: "int",    value: "2" }
       - { key: "LastPreLoginTasksPerformedBuild",             type: "string", value: "{{ ansible_osversion }}" }
-      - { key: "LastPreLoginTasksPerformedVersion",           type: "string", value: "{{ ansible_distribution_version }}" }
+      - { key: "LastPreLoginTasksPerformedVersion",           type: "string", value: "{{ ansible_facts['distribution_version'] }}" }
       - { key: "LastSeenBuddyBuildVersion",                   type: "string", value: "{{ ansible_osversion }}" }
-      - { key: "LastSeenCloudProductVersion",                 type: "string", value: "{{ ansible_distribution_version }}" }
-      - { key: "LastSeenDiagnosticsProductVersion",           type: "string", value: "{{ ansible_distribution_version }}" }
-      - { key: "LastSeenSiriProductVersion",                  type: "string", value: "{{ ansible_distribution_version }}" }
-      - { key: "LastSeenSyncProductVersion",                  type: "string", value: "{{ ansible_distribution_version }}" }
-      - { key: "LastSeeniCloudStorageServicesProductVersion", type: "string", value: "{{ ansible_distribution_version }}" }
+      - { key: "LastSeenCloudProductVersion",                 type: "string", value: "{{ ansible_facts['distribution_version'] }}" }
+      - { key: "LastSeenDiagnosticsProductVersion",           type: "string", value: "{{ ansible_facts['distribution_version'] }}" }
+      - { key: "LastSeenSiriProductVersion",                  type: "string", value: "{{ ansible_facts['distribution_version'] }}" }
+      - { key: "LastSeenSyncProductVersion",                  type: "string", value: "{{ ansible_facts['distribution_version'] }}" }
+      - { key: "LastSeeniCloudStorageServicesProductVersion", type: "string", value: "{{ ansible_facts['distribution_version'] }}" }
   # Privilege escalation to `target_user_id` is only required for inner steps when
   # the `target_user_id` doesn't match the `ansible_user_id`
   become: "{{ target_user_id != ansible_user_id }}"

--- a/tasks/setup-assistant.yml
+++ b/tasks/setup-assistant.yml
@@ -19,7 +19,7 @@
       - { key: "DidSeeTrueTonePrivacy",                       type: "bool",   value: "{{ SetupAssistant_DidSeeTrueTonePrivacy }}" }
       - { key: "DidSeeiCloudLoginForStorageServices",         type: "bool",   value: "{{ SetupAssistant_DidSeeiCloudLoginForStorageServices }}" }
       - { key: "SkipFirstLoginOptimization",                  type: "bool",   value: "{{ SetupAssistant_SkipFirstLoginOptimization }}" }
-      - { key: "LastPrivacyBundleVersion",                    type: "int",    value: "2" }
+      - { key: "LastPrivacyBundleVersion",                    type: "string", value: "2" }
       - { key: "LastPreLoginTasksPerformedBuild",             type: "string", value: "{{ ansible_osversion }}" }
       - { key: "LastPreLoginTasksPerformedVersion",           type: "string", value: "{{ ansible_facts['distribution_version'] }}" }
       - { key: "LastSeenBuddyBuildVersion",                   type: "string", value: "{{ ansible_osversion }}" }


### PR DESCRIPTION
BEFORE MERGING this PR please merge PR #5 
with this more complex sqlite3 instructions the desktop picture assignation should work with macOS 10.9 onward.
I have left commented settings that will allow in the future to also set Dynamic Desktop, but apparently the dynamic functionality changes depending on the macOS version so I will work on it another time