### PR TITLE
fix(FINDER,TRACKPAD): wrong types in osx 10.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Dock_LaunchAnim: yes                             # Animate opening applications
 Dock_Autohide: no                                # Automatically hide and show the Dock
 Dock_AutohideTimeModifier: 0                     # 0 - Disable, other Int value - Define Animation timing when hiding/showing the Dock
 Dock_ShowProcessIndicators: yes                  # Show indicator for open applications
+Dock_ShowRecentItems: yes                        # Show recent applications used in the dock (Catalina)
 Dock_ShowHidden: no                              # Display translucent Dock icons for hidden applications
 Dock_MouseOverHiliteStack: yes                   # Enable highlight hover effect for the grid view of a stack (Dock)
 ```

--- a/tasks/dock.yml
+++ b/tasks/dock.yml
@@ -46,6 +46,7 @@
       - { key: 'autohide',                 type: 'bool',    value: '{{ Dock_Autohide }}'}
       - { key: 'autohide-time-modifier',   type: 'int',     value: '{{ Dock_AutohideTimeModifier }}'}
       - { key: 'show-process-indicators',  type: 'boolean', value: '{{ Dock_ShowProcessIndicators }}'}
+      - { key: 'show-recents',             type: 'boolean', value: '{{ Dock_ShowRecentItems }}'}
       - { key: 'showhidden',               type: 'boolean', value: '{{ Dock_ShowHidden }}'}
       - { key: 'mouse-over-hilite-stack',  type: 'boolean', value: '{{ Dock_MouseOverHiliteStack }}'}
       - { key: 'mod-count',                type: 'int',     value: '1'}

--- a/tasks/finder.yml
+++ b/tasks/finder.yml
@@ -87,7 +87,7 @@
     osx_defaults: { domain: "{{ item.domain }}", key: "{{ item.key }}", type: "{{ item.type }}", value: "{{ item.value }}" }
     loop:
       - { domain: 'com.apple.finder', key: '_FXShowPosixPathInTitle', type: 'bool', value: '{{ Finder_FXShowPosixPathInTitle }}'}
-      - { domain: 'com.apple.finder', key: 'AppleShowAllFiles',       type: 'bool', value: '{{ Finder_AppleShowAllFiles }}'}
+      - { domain: 'com.apple.finder', key: 'AppleShowAllFiles',       type: 'string', value: '{{ Finder_AppleShowAllFiles }}'}
       - { domain: 'com.apple.finder', key: 'QLEnableTextSelection',   type: 'bool', value: '{{ Finder_QLEnableTextSelection }}'}
       - { domain: 'com.apple.finder', key: 'QuitMenuItem',            type: 'bool', value: '{{ Finder_QuitMenuItem }}'}
       - { domain: 'com.apple.desktopservices', key: 'DSDontWriteNetworkStores', type: 'bool', value: '{{ Finder_DSDontWriteNetworkStores }}'}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -292,7 +292,7 @@ Trackpad_Options:
   - { description: 'Clicking',                                 domain: "com.apple.AppleMultitouchTrackpad", key: 'Clicking', type: 'int',  value: "{{ EnabledDisabled_Options_Integer }}" }
   - { description: 'DragLock',                                 domain: "com.apple.AppleMultitouchTrackpad", key: 'DragLock',                                   type: 'int',  value: "{{ EnabledDisabled_Options_Integer }}" }
   - { description: 'Dragging',                                 domain: "com.apple.AppleMultitouchTrackpad", key: 'Dragging',                                   type: 'int',  value: "{{ EnabledDisabled_Options_Integer }}" }
-  - { description: 'Force Click & Haptic Feedback',            domain: "com.apple.AppleMultitouchTrackpad", key: 'ActuateDetents',                             type: 'bool',  value: "{{ EnabledDisabled_Options_Boolean }}" }
+  - { description: 'Force Click & Haptic Feedback',            domain: "com.apple.AppleMultitouchTrackpad", key: 'ActuateDetents',                             type: 'int',  value: "{{ EnabledDisabled_Options_Integer }}" }
   - { description: 'Force Click & Haptic Feedback',            domain: "com.apple.AppleMultitouchTrackpad", key: 'ForceSuppressed',                            type: 'bool',  value: "{{ EnabledDisabled_Options_Boolean }}" }
   - { description: 'Silent Clicking',                          domain: "com.apple.AppleMultitouchTrackpad", key: 'ActuationStrength',                          type: 'int',   value: "{{ EnabledDisabled_Options_Integer }}" }
   - { description: 'ClickHapticFeedback',                      domain: "com.apple.AppleMultitouchTrackpad", key: 'FirstClickThreshold',                        type: 'int',   value: "{{ Trackpad_ClickHapticFeedback_Options }}" }


### PR DESCRIPTION
These types weren't working for me on Catalina.  Have a look for yourself, but this is the only way I could use these settings.

(I tacked on a dock config item that I thought was sort of useful...)